### PR TITLE
Change OpenTelemetry collector version

### DIFF
--- a/.github/workflows/base-goreleaser-ci.yaml
+++ b/.github/workflows/base-goreleaser-ci.yaml
@@ -39,5 +39,5 @@ jobs:
         uses: goreleaser/goreleaser-action@v5
         with:
           workdir: distributions/${{ inputs.distribution }}
-          version: 0.102.0
+          version: latest
           args: --snapshot --rm-dist --timeout 2h

--- a/.github/workflows/base-goreleaser-ci.yaml
+++ b/.github/workflows/base-goreleaser-ci.yaml
@@ -39,5 +39,5 @@ jobs:
         uses: goreleaser/goreleaser-action@v5
         with:
           workdir: distributions/${{ inputs.distribution }}
-          version: latest
+          version: 0.102.0
           args: --snapshot --rm-dist --timeout 2h

--- a/.github/workflows/base-release.yaml
+++ b/.github/workflows/base-release.yaml
@@ -37,24 +37,16 @@ jobs:
       - name: Generate distribution sources
         run: make generate-sources
 
-      - name: Login to Docker Hub Registry
-        uses: docker/login-action@v3
-        with:
-          username: ${{ github.actor }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
-
       - name: Login to GitHub Package Registry
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: 108782066926.dkr.ecr.eu-central-1.amazonaws.com
+          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
-          version: latest
+          version: 0.102.0
           workdir: distributions/${{ inputs.distribution }}
           args: release --clean --timeout 2h
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/base-release.yaml
+++ b/.github/workflows/base-release.yaml
@@ -47,6 +47,6 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
-          version: 0.102.0
+          version: latest
           workdir: distributions/${{ inputs.distribution }}
           args: release --clean --timeout 2h

--- a/distributions/githubactions/.goreleaser.yaml
+++ b/distributions/githubactions/.goreleaser.yaml
@@ -61,7 +61,7 @@ dockers:
       goarch: "386"
       dockerfile: Dockerfile
       image_templates:
-        - ghcr.io/krzko/otelcol-distributions/githubactions:{{ .Version }}-386
+        - 108782066926.dkr.ecr.eu-central-1.amazonaws.com/research-dev:{{ .Version }}-386
       extra_files:
         - otelcol.yaml
       build_flag_templates:
@@ -77,7 +77,7 @@ dockers:
       goarch: amd64
       dockerfile: Dockerfile
       image_templates:
-        - ghcr.io/krzko/otelcol-distributions/githubactions:{{ .Version }}-amd64
+        - 108782066926.dkr.ecr.eu-central-1.amazonaws.com/research-dev:{{ .Version }}-amd64
       extra_files:
         - otelcol.yaml
       build_flag_templates:
@@ -93,7 +93,7 @@ dockers:
       goarch: arm64
       dockerfile: Dockerfile
       image_templates:
-        - ghcr.io/krzko/otelcol-distributions/githubactions:{{ .Version }}-arm64
+        - 108782066926.dkr.ecr.eu-central-1.amazonaws.com/research-dev:{{ .Version }}-arm64
       extra_files:
         - otelcol.yaml
       build_flag_templates:
@@ -109,7 +109,7 @@ dockers:
       goarch: ppc64le
       dockerfile: Dockerfile
       image_templates:
-        - ghcr.io/krzko/otelcol-distributions/githubactions:{{ .Version }}-ppc64le
+        - 108782066926.dkr.ecr.eu-central-1.amazonaws.com/research-dev:{{ .Version }}-ppc64le
       extra_files:
         - otelcol.yaml
       build_flag_templates:
@@ -122,12 +122,12 @@ dockers:
         - --label=org.opencontainers.image.source={{.GitURL}}
       use: buildx
 docker_manifests:
-    - name_template: ghcr.io/krzko/otelcol-distributions/githubactions:{{ .Version }}
+    - name_template: 108782066926.dkr.ecr.eu-central-1.amazonaws.com/research-dev:{{ .Version }}
       image_templates:
-        - ghcr.io/krzko/otelcol-distributions/githubactions:{{ .Version }}-386
-        - ghcr.io/krzko/otelcol-distributions/githubactions:{{ .Version }}-amd64
-        - ghcr.io/krzko/otelcol-distributions/githubactions:{{ .Version }}-arm64
-        - ghcr.io/krzko/otelcol-distributions/githubactions:{{ .Version }}-ppc64le
+        - 108782066926.dkr.ecr.eu-central-1.amazonaws.com/research-dev:{{ .Version }}-386
+        - 108782066926.dkr.ecr.eu-central-1.amazonaws.com/research-dev:{{ .Version }}-amd64
+        - 108782066926.dkr.ecr.eu-central-1.amazonaws.com/research-dev:{{ .Version }}-arm64
+        - 108782066926.dkr.ecr.eu-central-1.amazonaws.com/research-dev:{{ .Version }}-ppc64le
 sboms:
     - id: archive
       artifacts: archive

--- a/distributions/githubactions/Dockerfile
+++ b/distributions/githubactions/Dockerfile
@@ -3,10 +3,14 @@ FROM alpine:latest
 RUN apk add --upgrade --no-cache ca-certificates && update-ca-certificates
 
 ARG USER_UID=10001
+
 USER ${USER_UID}
 
-COPY githubactions /githubactions
+COPY _build/githubactions /githubactions
 COPY otelcol.yaml /etc/githubactions/config.yaml
-ENTRYPOINT ["/githubactions"]
-CMD ["--config", "/etc/githubactions/config.yaml"]
+
 EXPOSE 4317
+
+ENTRYPOINT ["/githubactions"]
+
+CMD ["--config", "/etc/githubactions/config.yaml"]

--- a/distributions/githubactions/manifest.yaml
+++ b/distributions/githubactions/manifest.yaml
@@ -1,30 +1,30 @@
 dist:
   module: github.com/krzko/otelcol-distributions/githubactions
-  name: otelcol
+  name: githubactions
   description: GitHub Actions distribution of the OpenTelemetry Collector
-  version: 0.99.0
+  version: 0.102.0
   output_path: ./_build
-  otelcol_version: 0.99.0
+  otelcol_version: 0.102.0
 
 receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/githubactionsreceiver v0.2.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.99.0
-  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.99.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.102.0
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.102.0
 
 processors:
-  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.99.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.99.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.99.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.99.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor v0.99.0        
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.99.0
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.102.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.102.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.102.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.102.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor v0.102.0        
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.102.0
 
 exporters:
-  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.99.0
-  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.99.0
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.102.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.102.0
 
 extensions:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.99.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.102.0
 
 replaces:
   - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/githubactionsreceiver => github.com/krzko/opentelemetry-collector-contrib/receiver/githubactionsreceiver feat-add-githubactionseventreceiver


### PR DESCRIPTION
OpenTelemetry collector version in use (`0.99.0`) was making the build fail with the error `missing method Float64Gauge`.

This version uses `go.opentelemetry.io/otel/sdk/metric` in version `v1.25.0`.

According to the discussion in [this link](https://github.com/Blueprint-uServices/blueprint/issues/176), the issue should be resolved in version `v1.27.0`.

This error seems to be fixed when using the collector in version `0.102.0`, which uses `go.opentelemetry.io/otel/sdk/metric` in version `v1.27.0`.